### PR TITLE
Swap to ensure_packages so if cryptsetup is defined elsewhere it stil…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,8 +51,6 @@ class luks(
   $package = 'cryptsetup',
 ) {
 
-  package { $package:
-    ensure => $ensure,
-  }
+  ensure_packages($package, {'ensure' => $ensure})
 
 }


### PR DESCRIPTION
…l works